### PR TITLE
Quick fix on Stimulus controllers

### DIFF
--- a/app/javascript/controllers/form_radio_buttons_controller.js
+++ b/app/javascript/controllers/form_radio_buttons_controller.js
@@ -1,67 +1,5 @@
 import { Controller } from "stimulus";
-
-const blue = {
-  classToApplyNotChecked: [
-    "flex",
-    "justify-center",
-    "items-center",
-    "bg-white",
-    "rounded",
-    "border-2",
-    "border-blue-200",
-  ],
-  classToApplyChecked: [
-    "flex",
-    "justify-center",
-    "items-center",
-    "bg-blue-200",
-    "rounded",
-    "border-2",
-    "border-blue-400",
-  ],
-};
-
-const red = {
-  classToApplyNotChecked: [
-    "flex",
-    "justify-center",
-    "items-center",
-    "bg-white",
-    "rounded",
-    "border-2",
-    "border-red-200",
-  ],
-  classToApplyChecked: [
-    "flex",
-    "justify-center",
-    "items-center",
-    "bg-red-200",
-    "rounded",
-    "border-2",
-    "border-red-400",
-  ],
-};
-
-const yellow = {
-  classToApplyNotChecked: [
-    "flex",
-    "justify-center",
-    "items-center",
-    "bg-white",
-    "rounded",
-    "border-2",
-    "border-yellow-200",
-  ],
-  classToApplyChecked: [
-    "flex",
-    "justify-center",
-    "items-center",
-    "bg-yellow-200",
-    "rounded",
-    "border-2",
-    "border-yellow-400",
-  ],
-};
+import { radio_style } from "../plugins_variables/radio_style";
 
 export default class extends Controller {
   static get targets() {
@@ -85,10 +23,7 @@ export default class extends Controller {
 
   toggleRadio(event) {
     const labelClicked = event.target;
-    console.log(labelClicked);
-
     const inputClicked = labelClicked.previousElementSibling;
-    console.log(inputClicked);
 
     // Check or uncheck on click
     event.preventDefault();
@@ -105,11 +40,13 @@ export default class extends Controller {
 
     radioParentsArray.forEach((parent) => {
       if (parent.children[0].checked) {
-        parent.classList.remove(...eval(btnColor).classToApplyNotChecked);
-        parent.classList.add(...eval(btnColor).classToApplyChecked);
+        parent.classList.remove(
+          ...radio_style[btnColor].classToApplyNotChecked
+        );
+        parent.classList.add(...radio_style[btnColor].classToApplyChecked);
       } else {
-        parent.classList.remove(...eval(btnColor).classToApplyChecked);
-        parent.classList.add(...eval(btnColor).classToApplyNotChecked);
+        parent.classList.remove(...radio_style[btnColor].classToApplyChecked);
+        parent.classList.add(...radio_style[btnColor].classToApplyNotChecked);
       }
     });
   }

--- a/app/javascript/plugins_variables/radio_style.js
+++ b/app/javascript/plugins_variables/radio_style.js
@@ -1,64 +1,64 @@
-const blue = {
-  classToApplyNotChecked: [
-    "flex",
-    "justify-center",
-    "items-center",
-    "bg-white",
-    "rounded",
-    "border-2",
-    "border-blue-200",
-  ],
-  classToApplyChecked: [
-    "flex",
-    "justify-center",
-    "items-center",
-    "bg-blue-200",
-    "rounded",
-    "border-2",
-    "border-blue-400",
-  ],
+const radio_style = {
+  blue: {
+    classToApplyNotChecked: [
+      "flex",
+      "justify-center",
+      "items-center",
+      "bg-white",
+      "rounded",
+      "border-2",
+      "border-blue-200",
+    ],
+    classToApplyChecked: [
+      "flex",
+      "justify-center",
+      "items-center",
+      "bg-blue-200",
+      "rounded",
+      "border-2",
+      "border-blue-400",
+    ],
+  },
+  red: {
+    classToApplyNotChecked: [
+      "flex",
+      "justify-center",
+      "items-center",
+      "bg-white",
+      "rounded",
+      "border-2",
+      "border-red-200",
+    ],
+    classToApplyChecked: [
+      "flex",
+      "justify-center",
+      "items-center",
+      "bg-red-200",
+      "rounded",
+      "border-2",
+      "border-red-400",
+    ],
+  },
+  yellow: {
+    classToApplyNotChecked: [
+      "flex",
+      "justify-center",
+      "items-center",
+      "bg-white",
+      "rounded",
+      "border-2",
+      "border-yellow-200",
+    ],
+    classToApplyChecked: [
+      "flex",
+      "justify-center",
+      "items-center",
+      "bg-yellow-200",
+      "rounded",
+      "border-2",
+      "border-yellow-400",
+    ],
+  },
 };
 
-const red = {
-  classToApplyNotChecked: [
-    "flex",
-    "justify-center",
-    "items-center",
-    "bg-white",
-    "rounded",
-    "border-2",
-    "border-red-200",
-  ],
-  classToApplyChecked: [
-    "flex",
-    "justify-center",
-    "items-center",
-    "bg-red-200",
-    "rounded",
-    "border-2",
-    "border-red-400",
-  ],
-};
-
-const yellow = {
-  classToApplyNotChecked: [
-    "flex",
-    "justify-center",
-    "items-center",
-    "bg-white",
-    "rounded",
-    "border-2",
-    "border-yellow-200",
-  ],
-  classToApplyChecked: [
-    "flex",
-    "justify-center",
-    "items-center",
-    "bg-yellow-200",
-    "rounded",
-    "border-2",
-    "border-yellow-400",
-  ],
-};
-
-export { blue, red, yellow };
+export { radio_style };


### PR DESCRIPTION
Refactored our form_radio_buttons_controller.js and radio_style.js to make the code cleaner by importing an object instead of 3 variables.

See this StackOverflow discussion tu understand why: [so](https://stackoverflow.com/questions/69606659/importing-a-variable-with-import-or-defining-it-with-const-in-the-module-has-a-b?noredirect=1#comment123097935_69606659)