### PR TITLE
Creating error messages

### DIFF
--- a/app/assets/stylesheets/errors.scss
+++ b/app/assets/stylesheets/errors.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the errors controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,16 @@
+class ErrorsController < ApplicationController
+  skip_before_action :authenticate_user!,
+                     only: %i[not_found unprocessable_entity internal_server_error]
+
+  def not_found
+    render status: 404
+  end
+
+  def unprocessable_entity
+    render status: 422
+  end
+
+  def internal_server_error
+    render status: 500
+  end
+end

--- a/app/helpers/errors_helper.rb
+++ b/app/helpers/errors_helper.rb
@@ -1,0 +1,2 @@
+module ErrorsHelper
+end

--- a/app/views/errors/components/_error_message.html.erb
+++ b/app/views/errors/components/_error_message.html.erb
@@ -1,0 +1,9 @@
+<div class="container-app mt-12">
+  
+  <div>
+    <h1 class="text-2xl font-semibold"><%= t("errors.#{error_type}.title") %></h1>
+    <h2 class="mt-1"><%= t("errors.#{error_type}.subtitle") %></h2>
+  </div>
+  
+  <p class="text-sm mt-4"><%= t("errors._shared.link_back.p1") %> <%= link_to t("errors._shared.link_back.p2"), root_path, class: "text-green-500 font-semibold" %></p>
+</div>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,0 +1,2 @@
+<h1>Errors#internal_server_error</h1>
+<p>Find me in app/views/errors/internal_server_error.html.erb</p>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,2 +1,1 @@
-<h1>Errors#internal_server_error</h1>
-<p>Find me in app/views/errors/internal_server_error.html.erb</p>
+<%= render "errors/components/error_message", error_type: "internal_server_error" %>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,0 +1,2 @@
+<h1>Errors#not_found</h1>
+<p>Find me in app/views/errors/not_found.html.erb</p>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,2 +1,1 @@
-<h1>Errors#not_found</h1>
-<p>Find me in app/views/errors/not_found.html.erb</p>
+<%= render "errors/components/error_message", error_type: "not_found" %>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,0 +1,2 @@
+<h1>Errors#unprocessable_entity</h1>
+<p>Find me in app/views/errors/unprocessable_entity.html.erb</p>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,2 +1,1 @@
-<h1>Errors#unprocessable_entity</h1>
-<p>Find me in app/views/errors/unprocessable_entity.html.erb</p>
+<%= render "errors/components/error_message", error_type: "unprocessable_entity" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,14 +10,20 @@ module MiniKeyz
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
+
+    # Application exceptions configuration, here Rails uses routes to handle it rather than prebuilt html files in public
+    config.exceptions_app = routes
+
+    # I18n configuration
     config.i18n.default_locale = :fr
     config.i18n.available_locales = %i[en fr]
 
     # Rails will look in our nested dictionnaries folder
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
 
-    # Config subdomain
+    # Subdomain configuration
     config.action_dispatch.tld_length = Integer(ENV['TLD_LENGTH'] || 1)
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,8 +14,8 @@ Rails.application.configure do
   # Do not eager load code on boot.
   config.eager_load = false
 
-  # Show full error reports.
-  config.consider_all_requests_local = true
+  # Show full error reports => true uses files in public ; false uses files handled through our routes
+  config.consider_all_requests_local = false
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.

--- a/config/locales/views/errors/global_errors.en.yml
+++ b/config/locales/views/errors/global_errors.en.yml
@@ -1,0 +1,15 @@
+en:
+  errors:
+    not_found:
+      title: "Page not found!"
+      subtitle: "Sorry, but the page you were looking for could not be found."
+    unprocessable_entity:
+      title: "Unprocessable entity"
+      subtitle: "The changes you are trying to make were rejected"
+    internal_server_error:
+      title: "Internal server error!"
+      subtitle: "Things are a bit unstable here. I suggets come back later."
+    _shared:
+      link_back:
+        p1: "You can"
+        p2: "return to our front page"

--- a/config/locales/views/errors/global_errors.fr.yml
+++ b/config/locales/views/errors/global_errors.fr.yml
@@ -1,0 +1,15 @@
+fr:
+  errors:
+    not_found:
+      title: "Page non trouvée !"
+      subtitle: "Désolé, mais nous ne trouvons pas la page que vous souhaitez rejoindre"
+    unprocessable_entity:
+      title: "Entité non traitable !"
+      subtitle: "Les modifications que vous avez apportées ne peuvent pas être sauvegardées"
+    internal_server_error:
+      title: "Erreur interne !"
+      subtitle: "Nous rencontrons des difficultés, nous vous prions de rééssayer plus tard"
+    _shared:
+      link_back:
+        p1: "Vous pouvez"
+        p2: "revenir sur notre page d'accueil"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  match '/404', to: 'errors#not_found', via: :all
+  match '/422', to: 'errors#unprocessable_entity', via: :all
+  match '/500', to: 'errors#internal_server_error', via: :all
+
   devise_for :users, controllers: { registrations: 'users/registrations' }
   root to: 'pages#home'
   get 'about', to: 'pages#about'

--- a/spec/helpers/errors_helper_spec.rb
+++ b/spec/helpers/errors_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the ErrorsHelper. For example:
+#
+# describe ErrorsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe ErrorsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe "Errors", type: :request do
+  describe "GET /not_found" do
+    it "returns http success" do
+      get "/errors/not_found"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /unprocessable_entity" do
+    it "returns http success" do
+      get "/errors/unprocessable_entity"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /internal_server_error" do
+    it "returns http success" do
+      get "/errors/internal_server_error"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/errors/internal_server_error.html.erb_spec.rb
+++ b/spec/views/errors/internal_server_error.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "errors/internal_server_error.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/errors/not_found.html.erb_spec.rb
+++ b/spec/views/errors/not_found.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "errors/not_found.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/errors/unprocessable_entity.html.erb_spec.rb
+++ b/spec/views/errors/unprocessable_entity.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "errors/unprocessable_entity.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# Handling 404, 422, 500
Our application is now able to display its proper error pages rather than default Rails ones. We used our component approach for the view which makes a perfect job!

We made it through thanks to these pages:
- https://medium.com/ruby-on-rails-web-application-development/custom-400-500-error-pages-in-ruby-on-rails-exception-handler-3a04975e4677
- https://web-crunch.com/posts/custom-error-page-ruby-on-rails